### PR TITLE
Give Command Fixes

### DIFF
--- a/mobot.rb
+++ b/mobot.rb
@@ -829,16 +829,16 @@ mobot = Cinch::Bot.new do
 		userGiver = mobot.get_user(m.user.to_s, $members)
 		userReciever = mobot.get_user(target,$members)
 		amount = Integer(amount)
-
 		fee = (amount*0.01).ceil
+        combined = amount + fee
 
-		if userGiver.credits >= (amount+fee)
-			userGiver.credits -= (amount + fee)
+		if userGiver.credits >= combined
+			userGiver.credits -= combined
 			userReciever.credits += amount
-			m.reply "#{userGiver.name} transfered #{amount} credits to #{userReciever.name}. #{fee} credits were charged for the transaction."
+			m.reply "#{userGiver.name} transfered #{amount} #{amount != 1 ? "credits" : "credit"} to #{userReciever.name}. #{fee} #{fee != 1 ? "credits were " : "credit was"} charged for the transaction."
 			mobot.update_db($members)
 		else
-			m.reply "You need #{amount+fee} credits to transfer #{amount} to #{userReciever.name}."
+			m.reply "You need #{combined} credits to transfer #{amount} to #{userReciever.name}."
 		end
 	end
 end

--- a/mobot.rb
+++ b/mobot.rb
@@ -825,14 +825,14 @@ mobot = Cinch::Bot.new do
         end
     end
 
-	on :message, /^.give (.+) (\d+)/ do |m, target, amount|
+	on :message, /^.give (\S+) (\d+)/ do |m, target, amount|
 		userGiver = mobot.get_user(m.user.to_s, $members)
 		userReciever = mobot.get_user(target,$members)
 		amount = Integer(amount)
 
 		fee = (amount*0.01).ceil
 
-		if userGiver.credits > (amount+fee)
+		if userGiver.credits >= (amount+fee)
 			userGiver.credits -= (amount + fee)
 			userReciever.credits += amount
 			m.reply "#{userGiver.name} transfered #{amount} credits to #{userReciever.name}. #{fee} credits were charged for the transaction."

--- a/mobot.rb
+++ b/mobot.rb
@@ -838,7 +838,7 @@ mobot = Cinch::Bot.new do
 			m.reply "#{userGiver.name} transfered #{amount} credits to #{userReciever.name}. #{fee} credits were charged for the transaction."
 			mobot.update_db($members)
 		else
-			m.reply "You need transfered #{amount+fee} credits to transfer #{amount}."
+			m.reply "You need #{amount+fee} credits to transfer #{amount} to #{userReciever.name}."
 		end
 	end
 end


### PR DESCRIPTION
There have been a few fixes and optimizations to the give routine.
* Improved regex to avoid giving credits to impossible usernames.
* Less recalculations for the cost of a single mem
* Fixed off by one error.
* Grammar for the grammernazis.